### PR TITLE
BUG: Fixed notices for unset object ID

### DIFF
--- a/includes/classes/class-pmpro-sws-landing-pages.php
+++ b/includes/classes/class-pmpro-sws-landing-pages.php
@@ -93,7 +93,7 @@ class PMPro_SWS_Landing_Pages {
 
 		// Check if this is the landing page
 		$queried_object = get_queried_object();
-		if ( empty( $queried_object ) ) {
+		if ( empty( $queried_object ) || empty( $queried_object->ID ) ) {
 			return;
 		}
 


### PR DESCRIPTION
The `$queried_object->ID ` will not be set under all circumstances. One example is when using bbPress, the forms page (i.e. example.com/forums)  does not have an associated ID for the queried object. 